### PR TITLE
CP-573 Release fluri 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 0.0.0
+version: 1.0.0
 description: 'Fluri is a fluent URI library built to make URI mutation easy'
 authors:
   - Workiva Client Platform Team <team-clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-573

JIRA and PR's included in this release: 


 CP-572  - fluri Travis CI commit  - https://github.com/Workiva/fluri/pull/7
 CP-571  - Add client platform team to authors  - https://github.com/Workiva/fluri/pull/6
 CP-570  - Add authors, documentation, homepage to pubspec  - https://github.com/Workiva/fluri/pull/5
 CP-568  - Update Apache 2.0 License  - https://github.com/Workiva/fluri/pull/4
 CP-567  - fluri Licenses  - https://github.com/Workiva/fluri/pull/2
 CP-566  - Fluent URI library (fluri)  - https://github.com/Workiva/fluri/pull/1

Diff Between Last Tag and Proposed Release: N/A

    