### PR TITLE
CP-583 Fix fluri documentation generation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,6 @@ authors:
   - Evan Weible <evan.weible@workiva.com>
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
-documentation:
 homepage: https://github.com/Workiva/fluri
 dev_dependencies:
   test: 0.12.0-rc.0


### PR DESCRIPTION
## Issue
- The `documentation:` field must be completely left out in order to trigger the automatic doc generation when publishing to pub.

## Changes
- Remove the `documentation:` field from `pubspec.yaml`

## Testing
- Travis-CI passes

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
