### PR TITLE
CP-642 Point travis-ci badge to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fluri [![Build Status](https://travis-ci.org/Workiva/fluri.svg?branch=travis-ci)](https://travis-ci.org/Workiva/fluri) [![Pub](https://img.shields.io/pub/v/fluri.svg)](https://pub.dartlang.org/packages/fluri)
+fluri [![Build Status](https://travis-ci.org/Workiva/fluri.svg?branch=master)](https://travis-ci.org/Workiva/fluri) [![Pub](https://img.shields.io/pub/v/fluri.svg)](https://pub.dartlang.org/packages/fluri)
 =====
 
 > Fluri is a fluent URI library for Dart built to make URI mutation easy.


### PR DESCRIPTION
## Issue
- Travis-CI badge was pointing to an old branch.

## Changes
- Updated Travis-CI badge in readme to point to master.

## Areas of Regression
- n/a

## Testing
- Travis-CI badge displays a successful build and the image url has `?branch=master` at the end.

## Code Review
@maxwellpeterson-wf
@jayudey-wf 