### PR TITLE
CP-657 Setup code coverage through codecov.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ pubspec.lock
 dartdoc-viewer/
 
 # coverage
-lcov_coverage.lcov
-lcov_report/
+coverage.lcov
+coverage_report/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: dart
 dart:
   - stable
 script:
-  - pub run test:test
+  - pub run test
+  - pub run dart_codecov_generator:generate_coverage --report-on=lib/ --no-html --verbose
+  - pub run dart_codecov coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ dart:
   - stable
 script:
   - pub run test
-  - pub run dart_codecov_generator:generate_coverage --report-on=lib/ --no-html --verbose
+  - pub run dart_codecov_generator --report-on=lib/ --no-html --verbose
   - pub run dart_codecov coverage.lcov
-  - pub run dart_style:format -n lib test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-fluri [![Build Status](https://travis-ci.org/Workiva/fluri.svg?branch=travis-ci)](https://travis-ci.org/Workiva/fluri)
+fluri [![Build Status](https://travis-ci.org/Workiva/fluri.svg?branch=travis-ci)](https://travis-ci.org/Workiva/fluri) [![codecov.io](http://codecov.io/github/Workiva/fluri/coverage.svg?branch=master)](http://codecov.io/github/Workiva/fluri?branch=master)
+
 =====
 
 > Fluri is a fluent URI library for Dart built to make URI mutation easy.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,15 +10,15 @@ homepage: https://github.com/Workiva/fluri
 dev_dependencies:
   coverage:
     git:
-      url: https://github.com/ekweible/coverage.git
+      url: git://github.com/ekweible/coverage.git
       ref: 796a265
   dart_codecov:
     git:
-      url: https://github.com/ekweible/dart_codecov.git
+      url: git://github.com/ekweible/dart_codecov.git
       ref: 0.1.0
   dart_codecov_generator:
     git:
-      url: https://github.com/ekweible/dart_codecov_generator.git
-      ref: 0.1.0
-  test: '>=0.12.0 <0.13.0'
+      url: git://github.com/ekweible/dart_codecov_generator.git
+      ref: 0.3.0
   dart_style: '>=0.1.8 <0.2.0'
+  test: '>=0.12.0 <0.12.3'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,16 @@ authors:
 documentation:
 homepage: https://github.com/Workiva/fluri
 dev_dependencies:
-  test: 0.12.0-rc.0
+  coverage:
+    git:
+      url: https://github.com/ekweible/coverage.git
+      ref: 796a265
+  dart_codecov:
+    git:
+      url: https://github.com/ekweible/dart_codecov.git
+      ref: 0.1.0
+  dart_codecov_generator:
+    git:
+      url: https://github.com/ekweible/dart_codecov_generator.git
+      ref: 0.1.0
+  test: '>=0.12.0 <0.13.0'

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Clean out old coverage artifacts
 if [ -d "./coverage_report" ]; then
     rm -rf ./coverage_report
 fi
@@ -7,5 +8,11 @@ if [ -f "./coverage.lcov" ]; then
     rm ./coverage.lcov
 fi
 
+# Collect coverage and generate report
 pub get
-pub global run dart_codecov_generator:generate_coverage --report-on=lib/ "$@"
+pub run dart_codecov_generator --report-on=lib/ "$@"
+
+# Open HTML report if successful
+if [ $? -eq 0 ] && [ -f "./coverage_report/index.html" ]; then
+    open coverage_report/index.html
+fi

--- a/tool/coverage.sh
+++ b/tool/coverage.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ -d "./lcov_report" ]; then
-    rm -rf ./lcov_report
+if [ -d "./coverage_report" ]; then
+    rm -rf ./coverage_report
 fi
-if [ -f "./lcov_coverage.lcov" ]; then
-    rm ./lcov_coverage.lcov
+if [ -f "./coverage.lcov" ]; then
+    rm ./coverage.lcov
 fi
 
 pub get
-pub global run dart_codecov_generator:generate_coverage test/fluri_test.dart
+pub global run dart_codecov_generator:generate_coverage --report-on=lib/ "$@"

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 pub get
-pub run test:test "$@"
+pub run test "$@"


### PR DESCRIPTION
## Issue
- We need to report and display our code coverage.

## Changes
**Source:**
- n/a

**Tools:**
- Coverage tools updated
- travis.yml updated to run and report coverage to codecov.io

**Tests:**
- n/a

**Other:**
- Readme updated to include code coverage badge (will only work once this is merged into master)

## Areas of Regression
- n/a

## Testing
- Coverage badge should be visible on README (will report "unknown" coverage until merged)
- Travis-ci should pass and this output should be visible in the logs towards the bottom:

    ```
    The command "pub run dart_codecov_generator --report-on=lib/ --no-html --verbose" exited with 0.
    pub run dart_codecov coverage.lcov
    Running dart_codecov...
    Coverage sent to codecov.io successfully.
    ```

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@jayudey-wf 