### PR TITLE
CP-662 Use dartanalyzer, fluri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ script:
   - pub run test
   - pub run dart_codecov_generator --report-on=lib/ --no-html --verbose
   - pub run dart_codecov coverage.lcov
+  - ./tool/analyze.sh

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -94,6 +94,7 @@ class Fluri extends FluriMixin {
     this.uri = Uri.parse(uri != null ? uri : '');
   }
 
+  @override
   String toString() => uri.toString();
 }
 

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dartanalyzer --fatal-warnings --no-hints lib/*.dart test/*.dart


### PR DESCRIPTION
## Issue
- We're not using dartanalyzer

## Changes
**Source:**
- n/a

**Tests:**
- n/a

**Tools:**
- Added a `analyze.sh` tool that runs the dartanalyzer

## Areas of Regression
- n/a

## Testing
- Travis-CI passes and the dartanalyzer output can be found at the end of the build logs

    ```
    $ ./tool/analyze.sh
    Analyzing [lib/fluri.dart, test/fluri_test.dart]...
    No issues found
    No issues found
    ```

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 