### PR TITLE
CP-704 Update docs to use "fluri" var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ With fluri, the above interactions are easy:
 ```dart
 import 'package:fluri/fluri.dart';
 
-Fluri uri = new Fluri()
+Fluri fluri = new Fluri()
   ..scheme = 'https'
   ..host = 'example.com'
   ..path = 'path/to/resource';
 
-uri
+fluri
   ..path = 'new/path'
   ..query = 'foo=true';
 
-uri.updateQuery({'bar': '10'});
+fluri.updateQuery({'bar': '10'});
 ```

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -34,13 +34,13 @@
 ///     import 'package:fluri/fluri.dart';
 ///
 ///     void main() {
-///       Fluri uri = new Fluri()
+///       Fluri fluri = new Fluri()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
 ///         ..queryParameters = {'limit': '10', 'format': 'json'};
 ///
-///       print(uri.toString());
+///       print(fluri.toString());
 ///       // https://example.com/path/to/resource?limit=10&format=json
 ///     }
 ///
@@ -75,14 +75,24 @@ library fluri;
 ///     import 'package:fluri/fluri.dart';
 ///
 ///     void main() {
-///       Fluri uri = new Fluri()
+///       Fluri fluri = new Fluri()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
 ///         ..queryParameters = {'limit': '10', 'format': 'json'};
 ///
-///       print(uri.toString());
+///       print(fluri.toString());
 ///       // https://example.com/path/to/resource?limit=10&format=json
+///     }
+///
+/// If you need access to the underlying `Uri` instance, you
+/// can access it via the `uri` property:
+///
+///     import 'package:fluri/fluri.dart';
+///
+///     void main() {
+///       Fluri fluri = new Fluri();
+///       Uri uri = fluri.uri;
 ///     }
 class Fluri extends FluriMixin {
 


### PR DESCRIPTION
## Issue
- To avoid confusion, we should recommend using "fluri" as the var name for `Fluri` instances.
- Discussion can be seen in #28.

## Changes
_Doc changes only_
- Updated docs/examples to use "fluri" as var name for `Fluri` instances.

## Areas of Regression
- n/a

## Testing
- n/a

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
