### PR TITLE
CP-816 Update code coverage collection and reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ dart:
 script:
   - pub run test
   - pub run dart_codecov_generator --report-on=lib/ --no-html --verbose
-  - pub run dart_codecov coverage.lcov
+  - bash <(curl -s https://codecov.io/bash)
   - ./tool/analyze.sh
   - ./tool/dartfmt.sh -e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,17 +8,7 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/fluri
 dev_dependencies:
-  coverage:
-    git:
-      url: git://github.com/ekweible/coverage.git
-      ref: 796a265
-  dart_codecov:
-    git:
-      url: git://github.com/ekweible/dart_codecov.git
-      ref: 0.1.0
-  dart_codecov_generator:
-    git:
-      url: git://github.com/ekweible/dart_codecov_generator.git
-      ref: 0.3.0
-  dart_style: '>=0.1.8 <0.2.0'
-  test: '>=0.12.0 <0.12.3'
+  coverage: "^0.7.2"
+  dart_codecov_generator: "^0.4.0"
+  dart_style: "^0.1.8"
+  test: "^0.12.0"


### PR DESCRIPTION
## Issue
- We need to confirm that code coverage still works with latest Dart SDK
- We are currently not reporting code coverage to codecov.io

## Changes
**Source:**
- None

**Tests:**
- None

**Tools:**
- Update versions of `coverage` package and coverage generation tool (https://github.com/codecov/dart)
  - [x] **TODO** coverage: use @0.7.2 from pub once released (the project maintainer is working on it now)
  - [x] **TODO** coverage generator: use a version from pub (https://github.com/codecov/dart/issues/3)
- Utilize codecov's bash coverage reporter (https://github.com/codecov/codecov-bash) to report coverage on CI builds

## Areas of Regression
- n/a

## Testing
- Travis CI marks this PR as passing checks (requires passing build)
- Codecov.io marks this PR as passing checks (requires 100% coverage)

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
fyi: @jayudey-wf 