### PR TITLE
CP-1153 Improvements/additions: appendToPath(), addPathSegment(), setQueryParam(), from() ctor, fromUri() ctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # dart
+.packages
 .pub
 packages
 pubspec.lock
 
 # docs
-dartdoc-viewer/
+/doc/api/
 
 # coverage
-coverage/
+/coverage/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ fluri
 fluri.updateQuery({'bar': '10'});
 ```
 
+Additional methods like `appendToPath` and `setQueryParam` make it easy to
+build on top of a base URL:
+
+```dart
+import 'package:fluri/fluri.dart';
+
+Fluri base = new Fluri('https://example.com/base/');
+
+Fluri fluri = new Fluri.from(base)
+  ..appendToPath('path/to/resource')
+  ..setQueryParam('count', '10');
+```
 
 ## Development
 

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -101,6 +101,14 @@ class Fluri extends FluriMixin {
     this.uri = Uri.parse(uri != null ? uri : '');
   }
 
+  /// Construct a new [Fluri] instance from another [Fluri] instance.
+  Fluri.from(Fluri fluri) : this.fromUri(fluri.uri);
+
+  /// Construct a new [Fluri] instance from a [Uri] instance.
+  Fluri.fromUri(Uri uri) {
+    this.uri = uri;
+  }
+
   @override
   String toString() => uri.toString();
 }
@@ -169,6 +177,16 @@ class FluriMixin {
     _uri = _uri.replace(pathSegments: pathSegments);
   }
 
+  /// Append to the current path.
+  void appendToPath(String path) {
+    this.path = this.path + path;
+  }
+
+  /// Add a single path segment to the end of the current path.
+  void addPathSegment(String pathSegment) {
+    pathSegments = pathSegments.toList()..add(pathSegment);
+  }
+
   /// The URI query string.
   String get query => _uri.query;
   void set query(String query) {
@@ -179,6 +197,11 @@ class FluriMixin {
   Map<String, String> get queryParameters => _uri.queryParameters;
   void set queryParameters(Map<String, String> queryParameters) {
     _uri = _uri.replace(queryParameters: queryParameters);
+  }
+
+  /// Set a single query parameter.
+  void setQueryParam(String param, String value) {
+    updateQuery({param: value});
   }
 
   /// Update the URI query parameters, merging the given map with the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"
   dart_style: "^0.2.0"
+  dartdoc: "^0.8.0"
   test: "^0.12.0"
 environment:
   sdk: ">=1.9.0 <2.0.0"

--- a/test/fluri_test.dart
+++ b/test/fluri_test.dart
@@ -17,7 +17,7 @@ library fluri.test.fluri_test;
 import 'package:fluri/fluri.dart';
 import 'package:test/test.dart';
 
-void commonFluriTests(dynamic getFluri()) {
+void commonFluriTests(FluriMixin getFluri()) {
   test('should allow setting the scheme', () {
     getFluri().scheme = 'https';
     expect(getFluri().scheme, equals('https'));
@@ -38,9 +38,32 @@ void commonFluriTests(dynamic getFluri()) {
     expect(getFluri().path, equals('/new/path'));
   });
 
+  test('should allow path with trailing slash', () {
+    getFluri().path = 'path/with/trailing/';
+    expect(getFluri().path, equals('/path/with/trailing/'));
+  });
+
   test('should allow setting the path via a list of path segments', () {
     getFluri().pathSegments = ['new', 'path'];
     expect(getFluri().pathSegments, equals(['new', 'path']));
+  });
+
+  test('should allow appending to the path', () {
+    getFluri().path = 'base/path/';
+    getFluri().appendToPath('segment');
+    expect(getFluri().path, equals('/base/path/segment'));
+  });
+
+  test('should allow appending multiple path segments', () {
+    getFluri().path = 'base/path/';
+    getFluri().appendToPath('with/additional/segments');
+    expect(getFluri().path, equals('/base/path/with/additional/segments'));
+  });
+
+  test('should allow adding a path segment', () {
+    getFluri().path = 'base/path';
+    getFluri().addPathSegment('segment');
+    expect(getFluri().path, equals('/base/path/segment'));
   });
 
   test('should allow setting the query', () {
@@ -51,6 +74,11 @@ void commonFluriTests(dynamic getFluri()) {
   test('should allow setting the query via a map of query parameters', () {
     getFluri().queryParameters = {'limit': '5', 'format': 'text'};
     expect(getFluri().query, equals('limit=5&format=text'));
+  });
+
+  test('should allow setting a single query parameter', () {
+    getFluri().setQueryParam('test', 'true');
+    expect(getFluri().queryParameters, containsPair('test', 'true'));
   });
 
   test('should allow updating the query parameters', () {
@@ -100,12 +128,28 @@ void main() {
       expect(fluri.toString(), equals('example.com/path'));
     });
 
+    test('should support constructing from another Fluri instance', () {
+      Fluri other = new Fluri('example.com');
+      expect(new Fluri.from(other).toString(), equals('example.com'));
+    });
+
+    test('should support constructing from a Uri instance', () {
+      var uriStr = 'https://example.com/path?query=true#fragment';
+      Uri uri = Uri.parse(uriStr);
+      expect(new Fluri.fromUri(uri).toString(), equals(uriStr));
+    });
+
     commonFluriTests(() => fluri);
   });
 
   group('FluriMixin', () {
-    ExtendingClass extender = new ExtendingClass(url);
-    MixingClass mixer = new MixingClass(url);
+    ExtendingClass extender;
+    MixingClass mixer;
+
+    setUp(() {
+      extender = new ExtendingClass(url);
+      mixer = new MixingClass(url);
+    });
 
     test('should be an empty uri by default', () {
       expect(new FluriMixin().uri.toString(), equals(''));


### PR DESCRIPTION
## Issue
- @oliverjanik suggested we add `addPathSegment()` and `setQueryParam()` (#39)
- missing some easy convenience constructors (from another `Fluri` instance, from a `Uri` instance)

## Changes
**Source:**
- Add `.from()` constructor for constructing from other `Fluri` instances
- Add `.fromUri()` constructor for constructing from `Uri` instances
- Add `.appendToPath()` for adding a path literal to the end of the current path
- Add `.addPathSegment()` for adding a single path segment to the end of the current path
- Add `.setQueryParam()` for setting a single parameter and value without having to use a map

**Tests:**
- Tests for all of these have been added

## Areas of Regression
- n/a

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 