### PR TITLE
CP-1244 Default to empty URI when uri set to null

### DIFF
--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -144,7 +144,7 @@ class FluriMixin {
   /// The full URI.
   Uri get uri => _uri;
   void set uri(Uri uri) {
-    _uri = uri;
+    _uri = uri ?? Uri.parse('');
   }
 
   /// The URI scheme or protocol. Examples: `http`, `https`, `ws`.

--- a/test/fluri_test.dart
+++ b/test/fluri_test.dart
@@ -155,6 +155,11 @@ void main() {
       expect(new FluriMixin().uri.toString(), equals(''));
     });
 
+    test('should be an empty uri even if uri set to null', () {
+      var fluri = new FluriMixin()..uri = null;
+      expect(fluri.uri.toString(), equals(''));
+    });
+
     commonFluriTests(() => extender);
     commonFluriTests(() => mixer);
   });


### PR DESCRIPTION
## Issue
- When using a class that mixes in `FluriMixin`, setting `.uri = null` will cause all other fluri methods to fail with a `NoSuchMethodError` on a null receiver.

## Changes
**Source:**
- When setting the `uri` field, fallback to an empty URI (`Uri.parse('')`) if the given value is `null`.

**Tests:**
- Add a test ensuring the `FluriMixin` supports this scenario.

## Areas of Regression
- Setting the full URI on a `FluriMixin` instance (covered by test)

## Testing
- CI passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 