### PR TITLE
CP-1245 Changelog: null uri bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.1
+
+- **Bug Fix:** `FluriMixin` now defaults to an empty URI when `uri` is set to
+  null.
+
 ## 1.1.0
 
 **New Features:**
@@ -19,4 +24,5 @@ _No source changes in this release._
 
 
 ## 1.0.0
-- Initial version of Fluri: a fluent URI library for Dart built to make URI mutation easy.
+- Initial version of Fluri: a fluent URI library for Dart built to make URI
+  mutation easy.


### PR DESCRIPTION
**Docs only change.**

Adds the null URI bugfix from #48 to the changelog.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 