### PR TITLE
CP-1176 Release fluri 1.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 1.1.0
+version: 1.1.1
 description: Fluri is a fluent URI library built to make URI mutation easy.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1176

JIRA and PR's included in this release: 


 CP-1228  - cleanup old scripts, fluri  - https://github.com/Workiva/fluri/pull/46
 CP-1242  - Fix changelog formatting issue, fluri  - https://github.com/Workiva/fluri/pull/47
 CP-1244  - Default to empty URI when uri set to null  - https://github.com/Workiva/fluri/pull/48
 CP-1245  - Changelog: null uri bugfix  - https://github.com/Workiva/fluri/pull/49

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/fluri/compare/1.1.0...CP-1176_release_1.1.1

