### PR TITLE
CP-1772 Analyzer: enable strong mode and linter.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,38 @@
+analyzer:
+  strong-mode: true
+
+linter:
+  rules:
+    - always_declare_return_types
+    - annotate_overrides
+    - avoid_as
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_return_types_on_setters
+    - await_only_futures
+    - camel_case_types
+    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_constructor_bodies
+    - hash_and_equals
+    - implementation_imports
+    - library_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - one_member_abstracts
+    - overriden_field
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - prefer_is_not_empty
+    - public_member_api_docs
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
+    - super_goes_last
+    - test_types_in_equals
+    - throw_in_finally
+    - type_annotate_public_apis
+    - type_init_formals
+    - unnecessary_brace_in_string_interp
+    - unnecessary_getters_setters

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -143,37 +143,37 @@ class FluriMixin {
 
   /// The full URI.
   Uri get uri => _uri;
-  void set uri(Uri uri) {
+  set uri(Uri uri) {
     _uri = uri ?? Uri.parse('');
   }
 
   /// The URI scheme or protocol. Examples: `http`, `https`, `ws`.
   String get scheme => _uri.scheme;
-  void set scheme(String scheme) {
+  set scheme(String scheme) {
     _uri = _uri.replace(scheme: scheme);
   }
 
   /// The URI host, including sub-domains and the tld.
   String get host => _uri.host;
-  void set host(String host) {
+  set host(String host) {
     _uri = _uri.replace(host: host);
   }
 
   /// The URI port number.
   int get port => _uri.port;
-  void set port(int port) {
+  set port(int port) {
     _uri = _uri.replace(port: port);
   }
 
   /// The URI path.
   String get path => _uri.path;
-  void set path(String path) {
+  set path(String path) {
     _uri = _uri.replace(path: path);
   }
 
   /// The URI path segments.
   Iterable<String> get pathSegments => _uri.pathSegments;
-  void set pathSegments(Iterable<String> pathSegments) {
+  set pathSegments(Iterable<String> pathSegments) {
     _uri = _uri.replace(pathSegments: pathSegments);
   }
 
@@ -189,13 +189,13 @@ class FluriMixin {
 
   /// The URI query string.
   String get query => _uri.query;
-  void set query(String query) {
+  set query(String query) {
     _uri = _uri.replace(query: query);
   }
 
   /// The URI query parameters.
   Map<String, String> get queryParameters => _uri.queryParameters;
-  void set queryParameters(Map<String, String> queryParameters) {
+  set queryParameters(Map<String, String> queryParameters) {
     _uri = _uri.replace(queryParameters: queryParameters);
   }
 
@@ -207,14 +207,14 @@ class FluriMixin {
   /// Update the URI query parameters, merging the given map with the
   /// current query parameters map instead of overwriting it.
   void updateQuery(Map<String, String> queryParameters) {
-    Map newQueryParameters = new Map.from(this.queryParameters);
+    var newQueryParameters = new Map<String, String>.from(this.queryParameters);
     newQueryParameters.addAll(queryParameters);
     _uri = _uri.replace(queryParameters: newQueryParameters);
   }
 
   /// The URI fragment or hash.
   String get fragment => _uri.fragment;
-  void set fragment(String fragment) {
+  set fragment(String fragment) {
     _uri = _uri.replace(fragment: fragment);
   }
 }

--- a/test/fluri_test.dart
+++ b/test/fluri_test.dart
@@ -17,6 +17,9 @@ library fluri.test.fluri_test;
 import 'package:fluri/fluri.dart';
 import 'package:test/test.dart';
 
+/// A suite of common tests that should be run against an instance of [Fluri],
+/// an instance of a class that extends [FluriMixin], and an instance of a class
+/// that mixes in [FluriMixin].
 void commonFluriTests(FluriMixin getFluri()) {
   test('should allow setting the scheme', () {
     getFluri().scheme = 'https';
@@ -92,18 +95,23 @@ void commonFluriTests(FluriMixin getFluri()) {
   });
 }
 
+/// A class to exercise extending [FluriMixin].
 class ExtendingClass extends FluriMixin {
+  /// Construct an instance from a [uri].
   ExtendingClass(String uri) {
     this.uri = Uri.parse(uri);
   }
 }
 
+/// A class to exercise mixing in [FluriMixin].
 class MixingClass extends Object with FluriMixin {
+  /// Construct an instance from a [uri].
   MixingClass(String uri) {
     this.uri = Uri.parse(uri);
   }
 }
 
+/// Runs the Fluri test suite.
 void main() {
   String url = 'http://example.com/path/to/resource?limit=10&format=list#test';
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -14,9 +14,12 @@
 
 library tool.dev;
 
+import 'dart:async';
+
 import 'package:dart_dev/dart_dev.dart' show dev, config;
 
-main(List<String> args) async {
+/// Run dart_dev with fluri's configuration.
+Future main(List<String> args) async {
   // https://github.com/Workiva/dart_dev
 
   List<String> directories = ['lib/', 'test/', 'tool/'];


### PR DESCRIPTION
## Improvement
We should leverage the analyzer's strong mode and linter.

## Changes
- Enable strong-mode and linter via `.analysis-options`
- Fix analyzer warnings, hints, and lints.

## Testing
- CI passes.

> There will be 9 lints about documenting all public members:
> ```
> [lint] Document all public members (/Users/evanweible/dev/workiva/cp/fluri/lib/fluri.dart, line 146, col 7)
> ```
> This is because it conflicts with the preference for documenting only the getter when both a getter and setter exist. This is documented here and will be fixed: https://github.com/dart-lang/linter/issues/237

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@sebastianmalysa-wf 
@jayudey-wf 