### PR TITLE
CP-2817 Support multi-value parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.2.0
+
+- **Feature:** Support for multi-value parameters.
+
+  See the [readme][https://github.com/Workiva/fluri/blob/master/README.md] for
+  usage examples.
+
+- **Dart SDK:** In order to support multi-value parameters, the minimum required
+  Dart SDK version is now 1.15.0 since that is when the `queryParametersAll`
+  field was added to the `Uri` class.
+
 ## 1.1.1
 
 - **Bug Fix:** `FluriMixin` now defaults to an empty URI when `uri` is set to

--- a/README.md
+++ b/README.md
@@ -66,6 +66,52 @@ Fluri fluri = new Fluri.from(base)
   ..setQueryParam('count', '10');
 ```
 
+Fluri also supports multi-value parameters. To access the query parameters as
+`Map<String, List<String>>`, use `queryParametersAll` (just like the `Uri`
+class):
+                                              
+```dart
+var fluri = new Fluri('/resource?format=json&format=text');
+print(fluri.queryParameters); // {'format': 'text'}
+print(fluri.queryParametersAll); // {'format': ['json', 'text']}
+```
+
+To set a single query parameter to multiple values:
+
+```dart
+var fluri = new Fluri('/resource');
+fluri.setQueryParam('format', ['json', 'text']);
+print(fluri.queryParametersAll); // {'format': ['json', 'text']}
+```
+
+Using `setQueryParam` will always replace existing values:
+
+```dart
+var fluri = new Fluri('/resource');
+fluri.setQueryParam('format', ['json', 'text']);
+fluri.setQueryParam('format', ['binary', 'text']);
+print(fluri.queryParametersAll); // {'format': ['binary', 'text']}
+```
+
+You can use the `queryParametersAll` setter to set the entire query with
+multi-value param support:
+
+```dart
+var fluri = new Fluri('/resource');
+fluri.queryParametersAll = {'format': ['json', 'text'], 'count': ['5']}
+print(fluri.queryParametersAll); // {'format': ['json', 'text'], 'count': ['5']}
+```
+
+Again, if you need to preserve existing query parameters, you can use the
+`updateQuery` method to do so. Set `mergeValues: true` and any values that you
+provide will be merged with existing values:
+
+```dart
+var fluri = new Fluri('/resource?format=json');
+fluri.updateQuery({'format': ['binary', 'text'], 'count': '5'}, mergeValues: true);
+print(fluri.queryParametersAll); // {'format': ['binary', 'json', 'text'], 'count': ['5']}
+```
+
 ## Development
 
 This project leverages [the dart_dev package](https://github.com/Workiva/dart_dev)

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -199,16 +199,77 @@ class FluriMixin {
     _uri = _uri.replace(queryParameters: queryParameters);
   }
 
+  /// The URI query parameters with support for multi-value params.
+  Map<String, List<String>> get queryParametersAll => _uri.queryParametersAll;
+  set queryParametersAll(Map<String, Iterable<String>> queryParameters) {
+    _uri = _uri.replace(queryParameters: queryParameters);
+  }
+
   /// Set a single query parameter.
-  void setQueryParam(String param, String value) {
+  ///
+  /// If the given query parameter name is already set, it will be completely
+  /// replaced with the given [value].
+  ///
+  /// Throws an [ArgumentError] if [value] is not a `String` or an
+  /// `Iterable<String>`.
+  void setQueryParam(String param, dynamic /*String|Iterable<String>*/ value) {
+    if (value is! String && value is! Iterable<String>) {
+      throw new ArgumentError.value(
+          value,
+          'value',
+          'Must be a String or '
+          'Iterable<String>');
+    }
+
     updateQuery({param: value});
   }
 
   /// Update the URI query parameters, merging the given map with the
   /// current query parameters map instead of overwriting it.
-  void updateQuery(Map<String, String> queryParameters) {
-    var newQueryParameters = new Map<String, String>.from(this.queryParameters);
-    newQueryParameters.addAll(queryParameters);
+  ///
+  /// Throws an [ArgumentError] if any value in the given
+  /// [queryParametersToUpdate] map is not a `String` or an `Iterable<String>`.
+  ///
+  /// If [mergeValues] is `false`, each parameter in [queryParametersToUpdate]
+  /// will be completely replaced with the new value.
+  ///
+  /// If [mergeValues] is `true`, the values for each parameter in
+  /// [queryParametersToUpdate] will be merged into the existing list of values
+  /// for that parameter. Duplicate values will be discarded.
+  void updateQuery(
+      Map<String, dynamic /*String|Iterable<String>*/ > queryParametersToUpdate,
+      {bool mergeValues: false}) {
+    final newQueryParameters = <String, List<String>>{};
+
+    // Copy the current query param values.
+    queryParametersAll.forEach((key, value) {
+      newQueryParameters[key] = new List.from(value);
+    });
+
+    // Update the query using the given params.
+    queryParametersToUpdate.forEach((key, value) {
+      // Initialize or reset the value list if it either does not already exist,
+      // or if we're not merging values.
+      if (!mergeValues || !newQueryParameters.containsKey(key)) {
+        newQueryParameters[key] = [];
+      }
+
+      // Add the param value(s) while eliminating duplicates.
+      // Throw an ArgumentError if any value is invalid.
+      if (value is String && !newQueryParameters.containsValue(value)) {
+        newQueryParameters[key].add(value);
+      } else if (value is Iterable<String>) {
+        for (var v in value) {
+          if (!newQueryParameters[key].contains(v)) {
+            newQueryParameters[key].add(v);
+          }
+        }
+      } else {
+        throw new ArgumentError('Query parameter "$key" has value "$value" '
+            'which is not a String or an Iterable<String>.');
+      }
+    });
+
     _uri = _uri.replace(queryParameters: newQueryParameters);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
   dartdoc: "^0.8.0"
   test: "^0.12.0"
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: ">=1.15.0 <2.0.0"


### PR DESCRIPTION
Fixes #3.

## Description
Dart added a `Map<String, List<String>> queryParametersAll` field to the `Uri` class in 1.15.0. With that, we can provide better support for multi-value params. Currently the only way to set a query param to multiple values is to use the `set query(String query)` setter to do it manually.

This PR adds support for multi-value parameters:

- Expose a `Map<String, List<String>> queryParametersAll` getter for parity with `Uri`

- Expose a `queryParametersAll(Map<String, List<String>> queryParameters)` setter to allow an easy way to set the entire query with support for multi-value parameters.

- Update `setQueryParam` to accept either `String` or `Iterable<String>` for the value.

- Update `updateQuery` to accept either `String` or `Iterable<String>` for any of the values.

- Add a `bool mergeValues` optional param to `updateQuery` in order to support updating the query without completely replacing existing values. Instead, new values will be merged with existing values. Duplicate values will be discarded.

## Testing
- [ ] CI passes (tests updated and added)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 
@sebastianmalysa-wf 

fyi: @seanburke-wf 