### PR TITLE
CP-2919, CP-1901 Bugfix: calling .appendToPath() can result in duplicate slashes in URI

### DIFF
--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -179,6 +179,9 @@ class FluriMixin {
 
   /// Append to the current path.
   void appendToPath(String path) {
+    if (this.path.endsWith('/') && path.startsWith('/')) {
+      path = path.substring(1);
+    }
     this.path = this.path + path;
   }
 

--- a/test/fluri_test.dart
+++ b/test/fluri_test.dart
@@ -63,6 +63,16 @@ void commonFluriTests(FluriMixin getFluri()) {
     expect(getFluri().path, equals('/base/path/with/additional/segments'));
   });
 
+  test('should append to the path without introducing double slashes', () {
+    getFluri().path = 'base/path/';
+    getFluri().appendToPath('/starts/with/slash');
+    expect(getFluri().path, equals('/base/path/starts/with/slash'));
+
+    getFluri().path = 'base/path';
+    getFluri().appendToPath('/starts/with/slash');
+    expect(getFluri().path, equals('/base/path/starts/with/slash'));
+  });
+
   test('should allow adding a path segment', () {
     getFluri().path = 'base/path';
     getFluri().addPathSegment('segment');


### PR DESCRIPTION
### Issue
Calling `.appendToPath()` can result in duplicate slashes in URI if the `path` is set with a trailing slash and `.appendToPath()` is called with a leading slash.

### Changes
**Source:**
* Check the existing path for a trailing slash, if it has one check the path given to `.appendToPath()` and remove a leading slash if it is there.

**Tests:**
* Add a test for this scenario.

### Testing
- CI Passes

### Code Review
@Workiva/client-platform-pp