### PR TITLE
CP-2928 Use individual username tags instead of group alias

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,4 +10,4 @@ Describe your issue here... _If it is a bug - PLEASE follow our
 ---
 
 
-__FYI:__ @Workiva/client-platform-pp
+__FYI:__ @dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ stability commitment in the README.
 
 ### Code Review
 
-@Workiva/client-platform-pp
+@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf


### PR DESCRIPTION
### Description

The @Workiva/client-platform-pp alias is restricted to the Workiva org, and thus can't be tagged by external users.


### Changes

Use our individual usernames in the Issue and PR templates.


### Semantic Versioning

<!--
Check all that apply. If you haven't already, check out our versioning and
stability commitment in the README.
-->

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Major**
  - [ ] This change removes part of the public API that was deprecated in a
        previous major version


### Testing/QA

- [ ] CI passes

<!-- Add other testing suggestions/requirements as necessary. -->


### Code Review

@Workiva/client-platform-pp 
