### PR TITLE
WP-4420 add lints for cancel_subscription and close_sink

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -11,6 +11,8 @@ linter:
     - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types
+    - cancel_subscriptions
+    - close_sink
     - constant_identifier_names
     - control_flow_in_finally
     - empty_constructor_bodies

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -26,7 +26,7 @@ Future main(List<String> args) async {
   config.analyze.entryPoints = directories;
   config.copyLicense.directories = directories;
   config.coverage.reportOn = ['lib/'];
-  config.format.directories = directories;
+  config.format.paths = directories;
   config.test.platforms = ['vm'];
 
   await dev(args);


### PR DESCRIPTION
### Description

<!-- Provide a summary of the problem or motivation for this change. -->
No lints for `cancel_subscription` and `close_sink`

### Changes

<!-- Summarize at a high-level the solution or changes you've submitted. -->
Add the lints.

### Semantic Versioning

<!--
Check all that apply. If you haven't already, check out our versioning and
stability commitment in the README.
-->

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Major**
  - [ ] This change removes part of the public API that was deprecated in a
        previous major version


### Testing/QA

- [ ] CI passes

<!-- Add other testing suggestions/requirements as necessary. -->


### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf
