### PR TITLE
WP-4420 Add recommended lint rules

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -11,6 +11,8 @@ linter:
     - avoid_return_types_on_setters
     - await_only_futures
     - camel_case_types
+    - cancel_subscriptions
+    - close_sinks
     - constant_identifier_names
     - control_flow_in_finally
     - empty_constructor_bodies


### PR DESCRIPTION

### Description

The recommended lint rules are not set in analysis options

### Changes

Added
    - cancel_subscriptions
    - close_sinks


### Semantic Versioning

<!--
Check all that apply. If you haven't already, check out our versioning and
stability commitment in the README.
-->

- [ ] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Major**
  - [ ] This change removes part of the public API that was deprecated in a
        previous major version


### Testing/QA

- [ ] CI passes

<!-- Add other testing suggestions/requirements as necessary. -->


### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf
