### PR TITLE
WP-2927 Release fluri 1.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 1.2.1
+version: 1.2.2
 description: Fluri is a fluent URI library built to make URI mutation easy.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-3657 : added docs.yml](https://github.com/Workiva/fluri/pull/61)
* [WP-4420 Add recommended lint rules](https://github.com/Workiva/fluri/pull/63)
* [CP-2928 Use individual username tags instead of group alias](https://github.com/Workiva/fluri/pull/60)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/fluri/compare/1.2.1...version-bump-fluri-1-2-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/fluri/compare/1.2.1...1.2.2