### PR TITLE
WP-4489 - Resolve dart_dev deprecation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ authors:
 homepage: https://github.com/Workiva/fluri
 dev_dependencies:
   coverage: "^0.7.2"
-  dart_dev: "^1.5.1"
+  dart_dev: "^1.7.6"
   dart_style: "^0.2.0"
   dartdoc: "^0.9.0"
   test: "^0.12.0"

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -26,7 +26,7 @@ Future main(List<String> args) async {
   config.analyze.entryPoints = directories;
   config.copyLicense.directories = directories;
   config.coverage.reportOn = ['lib/'];
-  config.format.directories = directories;
+  config.format.paths = directories;
   config.test.platforms = ['vm'];
 
   await dev(args);


### PR DESCRIPTION
### Description

- performed memory audit and found nothing relevant
- dart_dev deprecated directories and replaced with paths, so I made the change here and upgraded the min ddev dependency

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Major**
  - [ ] This change removes part of the public API that was deprecated in a
        previous major version

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf
