### PR TITLE
WP-6452 Release fluri 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 1.2.5
+
+- **Improvement:** Dart 2 compatible! CI now runs on Dart 2 stable and Dart 1.
+
+## 1.2.4
+
+- **Improvement:** Initial Dart 2 and DDC compatibility changes.
+
+- **Documentation:** Add a `CODEOWNERS` file.
+
+## 1.2.3
+
+- **Tech Debt:** Update some dependency ranges for DDC compatibility.
+
+## 1.2.2
+
+- **Tech Debt:** Add and address lints.
+
+## 1.2.1
+
+- **Bug Fix:** Calling `.appendToPath()` will check for and prevent double
+  slashes when joining the current path with the additional path.
+
+- **Documentation:** Add GitHub Issue and Pull Request templates.
+
 ## 1.2.0
 
 - **Feature:** Support for multi-value parameters.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 1.2.4
+version: 1.2.5
 description: Fluri is a fluent URI library built to make URI mutation easy.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* [update build](https://github.com/Workiva/fluri/pull/73)
* [AF-2471 Dart 2](https://github.com/Workiva/fluri/pull/74)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/fluri/compare/1.2.4...Workiva:release_1.2.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/fluri/compare/1.2.4...1.2.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4676368400908288/logs/)