### PR TITLE
CPLAT-7482: Run unit tests with dart2js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .pub
 packages
 pubspec.lock
+.dart_tool
 
 # docs
 /doc/api/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - 1.24.3
-  - 2.0.0
+  - stable
 
 # Re-use downloaded pub packages everywhere.
 cache:
@@ -10,7 +10,4 @@ cache:
     - $HOME/.pub-cache
 
 script:
-- dartfmt --set-exit-if-changed -w .
-- dartanalyzer lib test
-- pub run dependency_validator
-- pub run test
+  - ./validate.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+FROM google/dart:2.5 as dart2
 FROM google/dart:1.24.3
 
 WORKDIR /build/
 ADD pubspec.yaml /build
-RUN pub get
+COPY --from=dart2 /usr/lib/dart /usr/lib/dart2
+RUN _PUB_TEST_SDK_VERSION=1.24.3 /usr/lib/dart2/bin/pub get --no-precompile
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 FROM scratch

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -222,7 +222,7 @@ class FluriMixin {
           value,
           'value',
           'Must be a String or '
-          'Iterable<String>');
+              'Iterable<String>');
     }
 
     updateQuery({param: value});

--- a/validate.sh
+++ b/validate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+if [ $TRAVIS_DART_VERSION -ne 1.24.3 ]
+then
+    dartfmt --set-exit-if-changed -w .
+fi
+dartanalyzer lib test
+pub run dependency_validator
+pub run test


### PR DESCRIPTION
## Motivation
We are getting ready to ship Dart2 code to production.Since we compile that code with dart2js, it would be great to run unit tests with dart2js as well. This will provide more confidence in the shipped code.
## Changes
- Update `.gitignore`
- dart2 format
- Use `dart2.5`
- Use pub2 solver in Dockerfile

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
       - [ ] CI should be sufficient
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/fluri/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/fluri/blob/master/CONTRIBUTING.md#manual-testing-criteria
