### PR TITLE
CPLAT-7938: Remove broken link and unnecessary ToC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.2.8
+
+- Readme updates.
+
+## 1.2.7
+
+- Readme updates.
+
 ## 1.2.6
 
 - Drop Dart 1 support.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 # fluri
 
-[![Pub](https://img.shields.io/pub/v/fluri.svg)](https://pub.dartlang.org/packages/fluri)
+[![Pub](https://img.shields.io/pub/v/fluri.svg)](https://pub.dev/packages/fluri)
 [![Build Status](https://travis-ci.org/Workiva/fluri.svg?branch=master)](https://travis-ci.org/Workiva/fluri)
-[![codecov.io](http://codecov.io/github/Workiva/fluri/coverage.svg?branch=master)](http://codecov.io/github/Workiva/fluri?branch=master)
-[![documentation](https://img.shields.io/badge/Documentation-fluri-blue.svg)](https://www.dartdocs.org/documentation/fluri/latest/)
-
-- [Changelog/Release Notes](https://github.com/Workiva/fluri/releases)
-- [Examples/Usage](#examples-usage)
-- [Minimum Dart SDK](#dart-sdk)
-- [Versioning and Stability](#versioning-and-stability)
-- [Development](#development)
+[![documentation](https://img.shields.io/badge/Documentation-fluri-blue.svg)](https://pub.dev/documentation/fluri/latest/)
 
 ## Examples/Usage
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 1.2.7
+version: 1.2.8
 description: Fluri is a fluent URI library built to make URI mutation easy.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
# [CPLAT-7938](https://jira.atl.workiva.net/browse/CPLAT-7938)

- Remove the coverage link since it was broken and we're no longer reporting coverage in CI.
- Update the pub links to the new `pub.dev` domain
- Remove the ToC since the last PR removed a couple of the sections and it's no longer necessary