### PR TITLE
CPLAT-11688: Add a `removeQueryParam` method.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
 
 jobs:
   include:
-    - dart: 2.2.0
-      name: "SDK: 2.2.0"
+    - dart: 2.3.0
+      name: "SDK: 2.3.0"
       script:
         - dartanalyzer .
         - pub run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0
+
+- Add a `removeQueryParam()` method.
+
 ## 1.2.8
 
 - Readme updates.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM google/dart:2.5
+FROM google/dart:2
 WORKDIR /build/
 ADD pubspec.yaml .
-RUN pub get --no-precompile
+RUN pub get
 FROM scratch

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015 Workiva Inc.
+Copyright 2015-2020 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 fluri
-Copyright 2015 Workiva Inc.
+Copyright 2015-2020 Workiva Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you wanted to build a long URI from the individual pieces, you would do
 something like this:
 
 ```dart
-Uri uri = new Uri(
+var uri = Uri(
   scheme: 'https',
   host: 'example.com',
   path: 'path/to/resource'
@@ -34,7 +34,7 @@ uri = uri.replace(
 Now let's say you want update the query without losing what you already have:
 
 ```dart
-Map query = new Map.from(uri.queryParameters);
+var query = Map.from(uri.queryParameters);
 query['bar'] = '10';
 uri = uri.replace(queryParameters: query);
 ```
@@ -47,7 +47,7 @@ With fluri, the above interactions are easy:
 ```dart
 import 'package:fluri/fluri.dart';
 
-Fluri fluri = new Fluri()
+var fluri = Fluri()
   ..scheme = 'https'
   ..host = 'example.com'
   ..path = 'path/to/resource';
@@ -65,9 +65,9 @@ build on top of a base URL:
 ```dart
 import 'package:fluri/fluri.dart';
 
-Fluri base = new Fluri('https://example.com/base/');
+var base = Fluri('https://example.com/base/');
 
-Fluri fluri = new Fluri.from(base)
+var fluri = Fluri.from(base)
   ..appendToPath('path/to/resource')
   ..setQueryParam('count', '10');
 ```
@@ -77,7 +77,7 @@ Fluri also supports multi-value parameters. To access the query parameters as
 class):
 
 ```dart
-var fluri = new Fluri('/resource?format=json&format=text');
+var fluri = Fluri('/resource?format=json&format=text');
 print(fluri.queryParameters); // {'format': 'text'}
 print(fluri.queryParametersAll); // {'format': ['json', 'text']}
 ```
@@ -85,7 +85,7 @@ print(fluri.queryParametersAll); // {'format': ['json', 'text']}
 To set a single query parameter to multiple values:
 
 ```dart
-var fluri = new Fluri('/resource');
+var fluri = Fluri('/resource');
 fluri.setQueryParam('format', ['json', 'text']);
 print(fluri.queryParametersAll); // {'format': ['json', 'text']}
 ```
@@ -93,7 +93,7 @@ print(fluri.queryParametersAll); // {'format': ['json', 'text']}
 Using `setQueryParam` will always replace existing values:
 
 ```dart
-var fluri = new Fluri('/resource');
+var fluri = Fluri('/resource');
 fluri.setQueryParam('format', ['json', 'text']);
 fluri.setQueryParam('format', ['binary', 'text']);
 print(fluri.queryParametersAll); // {'format': ['binary', 'text']}
@@ -103,7 +103,7 @@ You can use the `queryParametersAll` setter to set the entire query with
 multi-value param support:
 
 ```dart
-var fluri = new Fluri('/resource');
+var fluri = Fluri('/resource');
 fluri.queryParametersAll = {'format': ['json', 'text'], 'count': ['5']}
 print(fluri.queryParametersAll); // {'format': ['json', 'text'], 'count': ['5']}
 ```
@@ -113,7 +113,7 @@ Again, if you need to preserve existing query parameters, you can use the
 provide will be merged with existing values:
 
 ```dart
-var fluri = new Fluri('/resource?format=json');
+var fluri = Fluri('/resource?format=json');
 fluri.updateQuery({'format': ['binary', 'text'], 'count': '5'}, mergeValues: true);
 print(fluri.queryParametersAll); // {'format': ['binary', 'json', 'text'], 'count': ['5']}
 ```

--- a/lib/fluri.dart
+++ b/lib/fluri.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2015-2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 ///     import 'package:fluri/fluri.dart';
 ///
 ///     void main() {
-///       Fluri fluri = new Fluri()
+///       var fluri = Fluri()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
@@ -53,7 +53,7 @@
 ///     class Request extends Object with FluriMixin {}
 ///
 ///     void main() {
-///       Request req = new Request()
+///       var req = Request()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
@@ -73,7 +73,7 @@ library fluri;
 ///     import 'package:fluri/fluri.dart';
 ///
 ///     void main() {
-///       Fluri fluri = new Fluri()
+///       var fluri = Fluri()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
@@ -95,8 +95,7 @@ library fluri;
 class Fluri extends FluriMixin {
   /// Construct a new [Fluri] instance.
   ///
-  /// A starting [uri] may be supplied which will be parsed
-  /// by [Uri].[Uri.parse].
+  /// A starting [uri] may be supplied which will be parsed by [Uri.parse].
   Fluri([String uri]) {
     this.uri = Uri.parse(uri != null ? uri : '');
   }
@@ -128,7 +127,7 @@ class Fluri extends FluriMixin {
 ///     class Request extends Object with FluriMixin {}
 ///
 ///     void main() {
-///       Request req = new Request()
+///       var req = Request()
 ///         ..host = 'example.com'
 ///         ..scheme = 'https'
 ///         ..path = 'path/to/resource'
@@ -226,6 +225,17 @@ class FluriMixin {
     }
 
     updateQuery({param: value});
+  }
+
+  /// Remove [param] from the URI query parameters.
+  ///
+  /// If there are multiple values with the key of [param], all will be removed.
+  /// If there is no query param with the key of [param], this does nothing.
+  void removeQueryParam(String param) {
+    _uri = _uri.replace(queryParameters: {
+      for (final key in queryParametersAll.keys)
+        if (key != param) key: List.of(queryParametersAll[key]),
+    });
   }
 
   /// Update the URI query parameters, merging the given map with the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,9 @@
 name: fluri
-version: 1.2.8
+version: 1.3.0
 description: Fluri is a fluent URI library built to make URI mutation easy.
-authors:
-  - Workiva Client Platform Team <clientplatform@workiva.com>
-  - Dustin Lessard <evan.weible@workiva.com>
-  - Evan Weible <evan.weible@workiva.com>
-  - Jay Udey <jay.udey@workiva.com>
-  - Max Peterson <maxwell.peterson@workiva.com>
-  - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/fluri
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   dependency_validator: ^1.4.0
   test: ^1.9.2

--- a/test/fluri_test.dart
+++ b/test/fluri_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2015 Workiva Inc.
+// Copyright 2015-2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,6 +146,26 @@ void commonFluriTests(FluriMixin getFluri()) {
       expect(getFluri().queryParametersAll['limit'], unorderedEquals(['5']));
       expect(getFluri().queryParametersAll['format'],
           unorderedEquals(['binary', 'text']));
+    });
+
+    test('should allow removing a query parameter', () {
+      final fluri = getFluri()
+        ..updateQuery({
+          'single': 'true',
+          'multi': ['one', 'two']
+        });
+      expect(fluri.queryParametersAll.keys,
+          allOf(contains('single'), contains('multi')));
+      fluri.removeQueryParam('multi');
+      expect(fluri.queryParametersAll['single'], ['true']);
+      expect(fluri.queryParametersAll.keys, isNot(contains('multi')));
+      fluri.removeQueryParam('single');
+      expect(fluri.queryParametersAll.keys, isNot(contains('single')));
+    });
+
+    test('should do nothing if removing a non-existant query parameter', () {
+      expect(
+          (getFluri()..removeQueryParam('none')).queryParameters, isNotEmpty);
     });
 
     test('should allow updating the query parameters ', () {


### PR DESCRIPTION
# [CPLAT-11688](https://jira.atl.workiva.net/browse/CPLAT-11688)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-11688)

Add a way to remove query param(s) from a URI:

```dart
Fluri('https://example.com/?foo')
  ..removeQueryParam('foo');
```
