### PR TITLE
Example of raising a dependency's maximum allowed version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,5 @@ homepage: https://github.com/Workiva/fluri
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
-  test: ^1.16.5
+  test: '>=1.16.5 <3.0.0'
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
Just an example :)

[_Created by Sourcegraph batch change `Workiva/example_upgrade_dependency_max`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/example_upgrade_dependency_max)