### PR TITLE
FW-166 Only run skynet on releases

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -5,6 +5,12 @@ image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from t
 size: small
 timeout: 600
 
+run:
+  on-pull-request: false
+  on-promotion: true
+  when-modified-file-name-is: 
+    - skynet.yaml
+
 env:
 # encrypted github token used for requests to api.github.com
  - secure: JXAQtMbN54jqPBxucpcY74F7553JTDBd5poxAAaFBiCuG/RZSVEQEBiP1LF1KhVwLT07z0pw0kf9dmNgxkl2iMKh+uM=


### PR DESCRIPTION
## Motivation
Currently the skynet config is running on pull requests as well as releases which is causing us to hit the github api rate limit, we don't really need to have the skynet config running on pull requests because it's just needed for release pipelines. 
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
Add a run config to skynet that limits running to just releases and if there are changes to the skynet.yaml
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
Run skynet only on releases
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/fluri/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/fluri/blob/master/CONTRIBUTING.md#manual-testing-criteria
