### PR TITLE
raise_min_dart_sdk_2_19

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 2.0.5
 description: Fluri is a fluent URI library built to make URI mutation easy.
 homepage: https://github.com/Workiva/fluri
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 dev_dependencies:
   test: ^1.15.7
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
# Summary
For Dart packages that have migrated to null safety (full or partial)
we can raise the minimum Dart SDK version to 2.19.0 instead of 2.12.0.
This will allow us to take advantage of new language features as soon as
files are migrated to null safety. We've shown that unmigrated consumers
do not have issues consuming packages with a higher minimum Dart SDK version.
# Changes
- Raise minimum Dart SDK version to 2.19.0
# QA
- [ ] CI passes

[_Created by Sourcegraph batch change `Workiva/raise_min_dart_sdk_2_19`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/raise_min_dart_sdk_2_19)