### PR TITLE
RM-146278 Release fluri 2.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fluri
-version: 2.0.5
+version: 2.0.6
 description: Fluri is a fluent URI library built to make URI mutation easy.
 homepage: https://github.com/Workiva/fluri
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FW-147 Change skynet config to check that github workflow passes](https://github.com/Workiva/fluri/pull/94)
	* [FW-166 Only run skynet on releases](https://github.com/Workiva/fluri/pull/95)
	* [Update to latest image of github ci verifier](https://github.com/Workiva/fluri/pull/96)
	* [Update references to the previous team name](https://github.com/Workiva/fluri/pull/97)
	* [FEDX-688 GHA OSS changes](https://github.com/Workiva/fluri/pull/99)
	* [FEDX-1716: Workiva Analysis Options v2](https://github.com/Workiva/fluri/pull/100)
	* [FEDX-1789: Migarte to gha-dart-oss](https://github.com/Workiva/fluri/pull/101)
	* [raise_min_dart_sdk_2_19](https://github.com/Workiva/fluri/pull/102)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/fluri/compare/2.0.5...Workiva:release_fluri_2.0.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/fluri/compare/2.0.5...2.0.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4676368400908288/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4676368400908288/?repo_name=Workiva%2Ffluri&pull_number=103)